### PR TITLE
Render eex expr inside html tags properly.

### DIFF
--- a/lib/heex_formatter/phases/format.ex
+++ b/lib/heex_formatter/phases/format.ex
@@ -167,6 +167,9 @@ defmodule HeexFormatter.Phases.Format do
 
   defp render_attribute(attr) do
     case attr do
+      {:root, {:expr, expr, _}} ->
+        ~s({#{expr}})
+
       {attr, {:string, value, _meta}} ->
         ~s(#{attr}="#{value}")
 

--- a/test/heex_formatter_test.exs
+++ b/test/heex_formatter_test.exs
@@ -271,7 +271,20 @@ defmodule HeexFormatterTest do
     )
   end
 
-  test "test" do
+  test "parse eex inside of html tags" do
+    assert_formatter_output(
+      """
+        <button {build_phx_attrs_dynamically()}>Test</button>
+      """,
+      """
+      <button {build_phx_attrs_dynamically()}>
+        Test
+      </button>
+      """
+    )
+  end
+
+  test "format long lines to be split into multiple lines" do
     assert_formatter_output(
       """
         <p><span>this is a long long long long long looooooong text</span><%= @product.value %> and more stuff over here</p>


### PR DESCRIPTION
I noticed that when we have eex expressions inside of HTML tag attributes, they would be rendered with `root` as attributes instead of being rendered directly, so for example:

Given this input:

```html
  <button {build_phx_attrs_dynamically()}>Test</button>
```

What was being the output:

```html
  <button root={build_phx_attrs_dynamically()}>Test</button>
```

With PR changes:
```html
  <button {build_phx_attrs_dynamically()}>Test</button>
```