### PR TITLE
Fix issue with case statement

### DIFF
--- a/lib/heex_formatter/phases/tokenizer.ex
+++ b/lib/heex_formatter/phases/tokenizer.ex
@@ -50,19 +50,19 @@ defmodule HeexFormatter.Phases.Tokenizer do
 
   defp tokenize({type, line, column, opt, expr}, acc) when type in @eex_expr do
     render = List.to_string(opt)
-    meta = %{column: column, line: line}
-    expr = String.trim(to_string(expr))
+    expr = expr |> List.to_string() |> String.trim()
+    block? = String.ends_with?(expr, "do") || String.ends_with?(expr, "->")
+    meta = %{column: column, line: line, block?: block?}
 
-    token =
+    {type, tag} =
       if render == "=" do
         tag = "<%= #{expr} %>"
-        meta = Map.put(meta, :block?, String.ends_with?(tag, "do %>"))
-        {:eex_tag_open, tag, meta}
+        {:eex_tag_render, tag}
       else
-        {:eex_tag_close, "<% #{expr} %>", meta}
+        {:eex_tag, "<% #{expr} %>"}
       end
 
-    {[token], acc}
+    {[{type, tag, meta}], acc}
   end
 
   defp tokenize(_node, acc) do

--- a/test/heex_formatter_test.exs
+++ b/test/heex_formatter_test.exs
@@ -301,4 +301,31 @@ defmodule HeexFormatterTest do
       """
     )
   end
+
+  test "handle eex case statement" do
+    input = """
+    <div>
+    <%= case {:ok, "elixir"} do %>
+    <% {:ok, text} -> %>
+    <%= text %>
+
+    <% {:error, error} -> %>
+    <%= error %>
+    <% end %>
+    </div>
+    """
+
+    expected = """
+    <div>
+      <%= case {:ok, "elixir"} do %>
+      <% {:ok, text} -> %>
+        <%= text %>
+      <% {:error, error} -> %>
+        <%= error %>
+      <% end %>
+    </div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/feliperenan/heex_formatter/issues/9

Given the input:

```HTML
<div>
<%= case {:ok, "elixir"} do %>
<% {:ok, text} -> %>
<%= text %>

<% {:error, error} -> %>
<%= error %>
<% end %>
</div>
```

That will be the output:

```
<div>
  <%= case {:ok, "elixir"} do %>
  <% {:ok, text} -> %>
    <%= text %>
  <% {:error, error} -> %>
    <%= error %>
  <% end %>
</div>
```