### PR TITLE
Break long texts into multiple lines

### DIFF
--- a/lib/heex_formatter/phases/format.ex
+++ b/lib/heex_formatter/phases/format.ex
@@ -83,14 +83,27 @@ defmodule HeexFormatter.Phases.Format do
   end
 
   defp token_to_string({:text, text, _meta}, state) do
+    # TODO: accept default_line_length as option.
+    max_line_length = @default_line_length
+    indent = indent_expression(state.indentation)
+
+    # Check if the text fits in the same line. If it doesn't, it will add a
+    # line break in the first space after the `max_line_length`.
+    text =
+      if String.length(text) > max_line_length do
+        regex = ~r/(.{#{max_line_length},}?)\s/
+        Regex.replace(regex, String.trim(text), "\\g{1}\n#{indent}")
+      else
+        String.trim(text)
+      end
+
     text =
       case state.previous_token do
         {:eex_tag_render, _tag, _meta} ->
-          " " <> String.trim(text)
+          " " <> text
 
         _token ->
-          indent = indent_expression(state.indentation)
-          "\n" <> indent <> String.trim(text)
+          "\n" <> indent <> text
       end
 
     %{state | html: state.html <> text}

--- a/test/heex_formatter_test.exs
+++ b/test/heex_formatter_test.exs
@@ -328,4 +328,31 @@ defmodule HeexFormatterTest do
 
     assert_formatter_output(input, expected)
   end
+
+  test "format a long parapraph" do
+    input = """
+    <div>
+      <p>this is a long long long long long long loooooooooooooooooooooong loooooooooooooong long long long long text</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    """
+
+    expected = """
+    <div>
+      <p>
+        this is a long long long long long long loooooooooooooooooooooong loooooooooooooong long long long
+        long text
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+        et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+        aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+        dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+        officia deserunt mollit anim id est laborum.
+      </p>
+    </div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
 end


### PR DESCRIPTION
Now long texts will be broken into multiple lines. The strategy here is
to break the text in the first space after the max_line_length defined.

Given the input:

```html
<div>
  <p>this is a long long long long long long loooooooooooooooooooooong loooooooooooooong long long long long text</p>
  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
</div>
```

That's the output

```html
<div>
  <p>
    this is a long long long long long long loooooooooooooooooooooong loooooooooooooong long long long
    long text
  </p>
  <p>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
    et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
    aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
    dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
    officia deserunt mollit anim id est laborum.
  </p>
</div>
```