### PR TITLE
Keep intentional line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Set `heex_line_length` to only set the line:lenght for the heex formatter.
 
 ```elixir
 [
-  plugins: [HeexFormatter],
-  inputs: ["{config,lib,test}/**/*.{ex,exs}"],
+  # ...omitted
   heex_line_length: 300
 ]
 ```

--- a/lib/heex_formatter.ex
+++ b/lib/heex_formatter.ex
@@ -1,6 +1,128 @@
 defmodule HeexFormatter do
   @moduledoc """
-  Documentation for `HeexFormatter`.
+  Format Heex templates from `.heex` files or `~H` sigils.
+
+  This is a plugin for Mix format:
+
+  https://hexdocs.pm/mix/main/Mix.Tasks.Format.html#module-plugins
+
+  ### Setup
+
+  add this project as a dependency in your `mix.exs`
+
+  defp deps do
+    [
+      # ...
+      {:heex_formatter, github: "feliperenan/heex_formatter"}
+    ]
+  end
+
+  Add it as plugin to your project `.formatter` file and make sure to put the
+  `heex` extension in the `input` option.
+
+  ```elixir
+  [
+    plugins: [HeexFormatter],
+    inputs: ["*.{heex,ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{heex,ex,exs}"],
+    # ...
+  ]
+  ```
+
+  ### options
+
+  * `line_length`: The formatter defaults to a maximum line length of 98 characters,
+    which can be overwritten with the `line_length` option in the `.formatter` file.
+
+    Set `heex_line_length` to only set the line:lenght for the heex formatter.
+
+    ```elixir
+    [
+      # ...omitted
+      heex_line_length: 300
+    ]
+    ```
+
+  ### Formatting
+
+  This formatter tries to be as consistency as possible with the Elixir formatter.
+  With that being said, you should expect a similar formatting experience.
+
+  Given a plain HTML like this:
+
+  ```eex
+    <section>
+    <h1>    Hello</h1>
+    </section>
+  ```
+
+  Will be formatted as:
+
+  ```eex
+  <section>
+    <h1>Hello</h1>
+  </section>
+  ```
+
+  It will break texts to the next line in case there a tag has attributes:
+
+  ```eex
+  <section>
+    <h1 class="my-class">
+      Hello
+    </h1>
+  </section>
+  ```
+
+  And when it is a eex expression:
+
+  ```eex
+  <section>
+    <h1>
+      <%= Hello %>
+    </h1>
+  </section>
+  ```
+
+  Speaking of ieex expressions. Since they are Elixir code, they are formatted
+  by Elixir formatter. We just make sure it is well indentend within tags.
+
+  ```eex
+  <secion>
+    <%= form_for @changeset,
+             Routes.user_path(@conn, :create),
+             class: "w-full p-3 rounded-md",
+             phx_change: "on_change",
+             fn f -> %>
+      <%= text_input(f, :name) %>
+    <% end %>
+  </section>
+  ```
+
+  It will keep intentional new lines. In fact, the formatter will always keep
+  one line in case you have inserted multiple ones:
+
+  ```eex
+  <section>
+
+
+    <h1>
+      <%= Hello %>
+    </h1>
+
+  </section>
+  ```
+
+  Will remove the extra line between `section` and `h1` tag keeping just one.
+
+  ```eex
+  <section>
+
+    <h1>
+      <%= Hello %>
+    </h1>
+
+  </section>
+  ```
   """
   @behaviour Mix.Tasks.Format
 

--- a/lib/heex_formatter/formatter.ex
+++ b/lib/heex_formatter/formatter.ex
@@ -122,7 +122,7 @@ defmodule HeexFormatter.Formatter do
   # Here we don't want to format anything but just return the text as it is.
   defp token_to_string({tag, text, _meta}, %{mode: mode} = state)
        when tag in ~w(text eex_tag eex_tag_render)a and mode in @special_modes do
-    %{state | buffer: [text | state.buffer]}
+    %{state | buffer: [String.trim_trailing(text) | state.buffer]}
   end
 
   defp token_to_string({:text, text, _meta}, state) do
@@ -141,7 +141,7 @@ defmodule HeexFormatter.Formatter do
   defp token_to_string({:tag_close, tag, _meta}, %{mode: mode} = state)
        when mode in @special_modes do
     indentation = state.indentation - 1
-    tag_closed = "#{indent_expression(indentation)}</#{tag}>"
+    tag_closed = indent_expression("</#{tag}>", indentation)
     %{state | buffer: [tag_closed | state.buffer], indentation: indentation, mode: :normal}
   end
 

--- a/lib/heex_formatter/tokenizer.ex
+++ b/lib/heex_formatter/tokenizer.ex
@@ -38,12 +38,9 @@ defmodule HeexFormatter.Tokenizer do
   end
 
   defp do_tokenize({:text, _line, _column, text}, {tokens, cont}) do
-    {tokens, cont} =
-      text
-      |> List.to_string()
-      |> HTMLTokenizer.tokenize("nofile", 0, [], tokens, cont)
-
-    {Enum.reject(tokens, &line_break?/1), cont}
+    text
+    |> List.to_string()
+    |> HTMLTokenizer.tokenize("nofile", 0, [], tokens, cont)
   end
 
   @eex_expr [:start_expr, :expr, :end_expr, :middle_expr]
@@ -67,10 +64,4 @@ defmodule HeexFormatter.Tokenizer do
   defp do_tokenize(_node, acc) do
     acc
   end
-
-  defp line_break?({:text, text, _meta}) do
-    String.trim(text) == ""
-  end
-
-  defp line_break?(_node), do: false
 end

--- a/test/heex_formatter_test.exs
+++ b/test/heex_formatter_test.exs
@@ -336,7 +336,7 @@ defmodule HeexFormatterTest do
     <div>
     <script>
     function my_confirm(event) {
-      if (!confirm(' <%= "confirmation text" %> ')) {
+      if (!confirm('<%= "confirmation text" %>')) {
       event.stopPropagation()
     }
       return false;
@@ -355,7 +355,7 @@ defmodule HeexFormatterTest do
     <div>
       <script>
     function my_confirm(event) {
-      if (!confirm(' <%= "confirmation text" %> ')) {
+      if (!confirm('<%= "confirmation text" %>')) {
       event.stopPropagation()
     }
       return false;

--- a/test/heex_formatter_test.exs
+++ b/test/heex_formatter_test.exs
@@ -32,23 +32,12 @@ defmodule HeexFormatterTest do
   test "remove unwanted empty lines" do
     assert_formatter_output(
       """
-
-
       <section>
-
-
-
       <div>
       <h1>    Hello</h1>
       <h2>
-
-
       Sub title
-
       </h2>
-
-
-
       </div>
       </section>
 
@@ -283,6 +272,7 @@ defmodule HeexFormatterTest do
       """,
       """
       <p>$ <%= @product.value %> in Dollars</p>
+
       <button>Submit</button>
       """
     )
@@ -321,7 +311,6 @@ defmodule HeexFormatterTest do
     <%= case {:ok, "elixir"} do %>
     <% {:ok, text} -> %>
     <%= text %>
-
     <% {:error, error} -> %>
     <%= error %>
     <% end %>
@@ -586,7 +575,6 @@ defmodule HeexFormatterTest do
       <tr>
         <th>Name</th>
         <th>Age</th>
-
         <th></th>
         <th>
         </th>
@@ -690,6 +678,44 @@ defmodule HeexFormatterTest do
           <!-- <%= 1 %> --><!-- <%= 2 %> -->
     <div>
       <p>Hello</p>
+    </div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "keep single line breaks" do
+    input = """
+    <div>
+    <h2><%= @title %></h2>
+
+    <.form id="user-form" let={f} for={@changeset} phx-submit="save" >
+      <%= text_input f, :name %>
+      <%= error_tag(f, :name) %>
+
+      <%= number_input(f, :age) %>
+      <%= error_tag(f, :age) %>
+
+      <%= submit("Save", phx_disable_with: "Saving...") %>
+    </.form>
+    </div>
+    """
+
+    expected = """
+    <div>
+      <h2>
+        <%= @title %>
+      </h2>
+
+      <.form id="user-form" let={f} for={@changeset} phx-submit="save">
+        <%= text_input(f, :name) %>
+        <%= error_tag(f, :name) %>
+
+        <%= number_input(f, :age) %>
+        <%= error_tag(f, :age) %>
+
+        <%= submit("Save", phx_disable_with: "Saving...") %>
+      </.form>
     </div>
     """
 


### PR DESCRIPTION
This PR changes the formatter to keep lines breaks when it is just one. It means that, in case developers add a line break, it will be kept.

Given the input:

```eex
<div>
  <h2><%= @title %></h2>

  <.form id="user-form" let={f} for={@changeset} phx-submit="save">
    <%= text_input(f, :name) %>
    <%= error_tag(f, :name) %>

    <%= number_input(f, :age) %>
    <%= error_tag(f, :age) %>

    <%= submit("Save", phx_disable_with: "Saving...") %>

  </.form>
</div>
```

That's the output

```eex
<div>
  <h2>
    <%= @title %>
  </h2>

  <.form id="user-form" let={f} for={@changeset} phx-submit="save">
    <%= text_input(f, :name) %>
    <%= error_tag(f, :name) %>

    <%= number_input(f, :age) %>
    <%= error_tag(f, :age) %>

    <%= submit("Save", phx_disable_with: "Saving...") %>

  </.form>
</div>
```