### PR TITLE
Fix texts after eex render blocks

### DIFF
--- a/lib/heex_formatter/formatter.ex
+++ b/lib/heex_formatter/formatter.ex
@@ -449,6 +449,11 @@ defmodule HeexFormatter.Formatter do
   defp mode(_tag), do: :normal
 
   # Returns how given text formatted according to the current state.
+  defp handle_text(text, %{previous_token: {:eex_tag_render, _tag, %{block?: true}}} = state) do
+    indent = indent_expression(state.indentation)
+    "\n" <> indent <> String.trim(text)
+  end
+
   defp handle_text(text, %{previous_token: {:eex_tag_render, _tag, _meta}}) do
     " " <> String.trim(text)
   end

--- a/test/heex_formatter_test.exs
+++ b/test/heex_formatter_test.exs
@@ -797,4 +797,19 @@ defmodule HeexFormatterTest do
 
     assert_formatter_output(input, expected)
   end
+
+  test "format label block correctly" do
+    input = """
+    <%= label @f, :email_address, class: "text-gray font-medium" do %> Email Address
+    <% end %>
+    """
+
+    expected = """
+    <%= label @f, :email_address, class: "text-gray font-medium" do %>
+      Email Address
+    <% end %>
+    """
+
+    assert_formatter_output(input, expected)
+  end
 end


### PR DESCRIPTION
The formatter wasn't formatting texts after eex render blocks correctly, for instance:

The input:

```eex
<%= label f, :email_address, class: "text-gray font-medium" do %>
  Email Address
<% end %>
```

Became:

```eex
<%= label f, :email_address, class: "text-gray font-medium" do %>Email Address
<% end %>
```

This commit address this issue keeping the text indented in the next line.