### PR TITLE
Remove extraneous comment in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,9 +21,6 @@ defmodule HeexFormatter.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # Just while this PR gets merged:
-      #
-      # https://github.com/phoenixframework/phoenix_live_view/pull/1847
       {:phoenix_live_view, "~> 0.17.7"},
       {:jason, "~> 1.3"},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix_live_view/pull/1847 has already been merged and released so we don't need the comment about waiting for it to be merged.