### PR TITLE
Add steps to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Add it to your projects `.formatter.exs` file
 ]
 ```
 
+Get the dep
+
+```elixir
+mix deps.get
+```
+
+Compile
+
+```elixir
+mix compile
+```
+
 Now run
 
 ```elixir


### PR DESCRIPTION
Add `mix deps.get` and `mix.compile` steps to `README.md`, to prevent errors like [this one](https://github.com/feliperenan/heex_formatter/issues/3#issuecomment-1046275618)